### PR TITLE
refactor: Remove core dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,75 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Alamofire",
-        "repositoryURL": "https://github.com/Alamofire/Alamofire",
-        "state": {
-          "branch": null,
-          "revision": "3dc6a42c7727c49bf26508e29b0a0b35f9c7e1ad",
-          "version": "5.8.1"
-        }
-      },
-      {
-        "package": "CocoaLumberjack",
-        "repositoryURL": "https://github.com/CocoaLumberjack/CocoaLumberjack",
-        "state": {
-          "branch": null,
-          "revision": "363ed23d19a931809ea834a7d722da830353806a",
-          "version": "3.8.2"
-        }
-      },
-      {
-        "package": "InfomaniakCore",
-        "repositoryURL": "https://github.com/Infomaniak/ios-core",
-        "state": {
-          "branch": null,
-          "revision": "504932a51c978b6aa0bbc086054875a36241674e",
-          "version": "5.0.1"
-        }
-      },
-      {
         "package": "InfomaniakDI",
         "repositoryURL": "https://github.com/Infomaniak/ios-dependency-injection",
         "state": {
           "branch": null,
           "revision": "8dc9e67e6d3d9f4f5bd02d693a7ce1f93b125bcd",
           "version": "2.0.1"
-        }
-      },
-      {
-        "package": "RealmDatabase",
-        "repositoryURL": "https://github.com/realm/realm-core.git",
-        "state": {
-          "branch": null,
-          "revision": "7227d6a447821c28895daa099b6c7cd4c99d461b",
-          "version": "13.25.1"
-        }
-      },
-      {
-        "package": "Realm",
-        "repositoryURL": "https://github.com/realm/realm-swift",
-        "state": {
-          "branch": null,
-          "revision": "836cc4b8619886f979f8961c3f592a82b0741591",
-          "version": "10.45.3"
-        }
-      },
-      {
-        "package": "Sentry",
-        "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
-        "state": {
-          "branch": null,
-          "revision": "3b9a8e69ca296bd8cd0e317ad7a448e5daf4a342",
-          "version": "8.18.0"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-          "version": "1.5.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
         name: "InfomaniakLogin",
         platforms: [
-            .iOS(.v13),
+            .iOS(.v12),
             .macOS(.v11)
         ],
         products: [
@@ -15,13 +15,13 @@ let package = Package(
                     targets: ["InfomaniakLogin"]),
         ],
         dependencies: [
-            .package(url: "https://github.com/Infomaniak/ios-core", .upToNextMajor(from: "5.0.1")),
+            .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.0")),
         ],
         targets: [
             .target(
                     name: "InfomaniakLogin",
                     dependencies: [
-                        .product(name: "InfomaniakCore", package: "ios-core"),
+                        .product(name: "InfomaniakDI", package: "ios-dependency-injection"),
                     ]),
             .testTarget(
                     name: "InfomaniakLoginTests",

--- a/Sources/InfomaniakLogin/Config.swift
+++ b/Sources/InfomaniakLogin/Config.swift
@@ -1,0 +1,55 @@
+/*
+ Copyright 2023 Infomaniak Network SA
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+public enum AccessType: String {
+    case offline
+}
+
+public enum ResponseType: String {
+    case code
+}
+
+public extension InfomaniakLogin {
+    struct Config {
+        let clientId: String
+        let loginURL: URL
+        let redirectURI: String
+        let responseType: ResponseType
+        let accessType: AccessType
+        let hashMode: String
+        let hashModeShort: String
+
+        public init(
+            clientId: String,
+            loginURL: URL = URL(string: "https://login.infomaniak.com/")!,
+            redirectURI: String = "\(Bundle.main.bundleIdentifier ?? "")://oauth2redirect",
+            responseType: ResponseType = .code,
+            accessType: AccessType = .offline,
+            hashMode: String = "SHA-256",
+            hashModeShort: String = "S256"
+        ) {
+            self.clientId = clientId
+            self.loginURL = loginURL
+            self.redirectURI = redirectURI
+            self.responseType = responseType
+            self.accessType = accessType
+            self.hashMode = hashMode
+            self.hashModeShort = hashModeShort
+        }
+    }
+}

--- a/Sources/InfomaniakLogin/Config.swift
+++ b/Sources/InfomaniakLogin/Config.swift
@@ -17,6 +17,7 @@
 import Foundation
 
 public enum AccessType: String {
+    /// When using `offline` accessToken has an expiration date and a refresh token is returned by the back-end
     case offline
 }
 
@@ -34,6 +35,16 @@ public extension InfomaniakLogin {
         let hashMode: String
         let hashModeShort: String
 
+        /// Initializes an OAuth2 configuration for a given Infomaniak client app
+        ///
+        /// - Parameters:
+        ///   - clientId: An identifier provided by the backend.
+        ///   - loginURL: Base URL for login calls, defaults to production. Can be replaced with preprod.
+        ///   - redirectURI: Should match the app bundle ID.
+        ///   - responseType: The response type, currently only supports `.code`.
+        ///   - accessType: Use `.offline` for refresh token-based auth, `.none` or `nil` for non expiring token.
+        ///   - hashMode: The hash mode, defaults to "SHA-256".
+        ///   - hashModeShort: A short version of the hash mode, defaults to "S256".
         public init(
             clientId: String,
             loginURL: URL = URL(string: "https://login.infomaniak.com/")!,

--- a/Sources/InfomaniakLogin/DeleteAccountViewController.swift
+++ b/Sources/InfomaniakLogin/DeleteAccountViewController.swift
@@ -15,7 +15,7 @@
  */
 
 #if canImport(UIKit)
-import InfomaniakCore
+import InfomaniakDI
 import UIKit
 import WebKit
 
@@ -25,6 +25,8 @@ public protocol DeleteAccountDelegate: AnyObject {
 }
 
 public class DeleteAccountViewController: UIViewController {
+    @LazyInjectService var infomaniakLogin: InfomaniakLoginable
+    
     private var webView: WKWebView!
     private var progressView: UIProgressView!
     public var navBarColor: UIColor?
@@ -142,7 +144,7 @@ extension DeleteAccountViewController: WKNavigationDelegate {
     ) {
         if let url = navigationAction.request.url {
             let urlString = url.absoluteString
-            if urlString.starts(with: Constants.LOGIN_URL) {
+            if url.host == infomaniakLogin.config.loginURL.host {
                 decisionHandler(.allow)
                 dismiss(animated: true)
                 if !accountDeleted {

--- a/Sources/InfomaniakLogin/DeleteAccountViewController.swift
+++ b/Sources/InfomaniakLogin/DeleteAccountViewController.swift
@@ -48,7 +48,7 @@ public class DeleteAccountViewController: UIViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
 
-        if let url = Constants.autologinUrl(to: Constants.DELETEACCOUNT_URL) {
+        if let url = Constants.autologinUrl(to: Constants.deleteAccountURL) {
             if let accessToken = accessToken {
                 var request = URLRequest(url: url)
                 request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")

--- a/Sources/InfomaniakLogin/InfomaniakLogin.swift
+++ b/Sources/InfomaniakLogin/InfomaniakLogin.swift
@@ -24,7 +24,7 @@ import UIKit
 #endif
 
 public enum Constants {
-    public static let DELETEACCOUNT_URL =
+    public static let deleteAccountURL =
         "https://manager.infomaniak.com/v3/ng/profile/user/dashboard?open-terminate-account-modal"
     public static func autologinUrl(to destination: String) -> URL? {
         return URL(string: "https://manager.infomaniak.com/v3/mobile_login/?url=\(destination)")

--- a/Sources/InfomaniakLogin/Model/ApiDeleteToken.swift
+++ b/Sources/InfomaniakLogin/Model/ApiDeleteToken.swift
@@ -1,0 +1,23 @@
+/*
+ Copyright 2023 Infomaniak Network SA
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+public class ApiDeleteToken: Codable {
+    let result: String
+    let error: String?
+    let data: Bool?
+}

--- a/Sources/InfomaniakLogin/Model/ApiToken.swift
+++ b/Sources/InfomaniakLogin/Model/ApiToken.swift
@@ -16,14 +16,14 @@
 
 import Foundation
 
-@objc public class ApiToken: NSObject, Codable {
-    @objc public var accessToken: String
-    @objc public var expiresIn: Int
-    @objc public var refreshToken: String
-    @objc public var scope: String
-    @objc public var tokenType: String
-    @objc public var userId: Int
-    @objc public var expirationDate: Date
+public class ApiToken: NSObject, Codable {
+    public let accessToken: String
+    public let expiresIn: Int
+    public let refreshToken: String
+    public let scope: String
+    public let tokenType: String
+    public let userId: Int
+    public let expirationDate: Date
 
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"

--- a/Sources/InfomaniakLogin/Model/ApiToken.swift
+++ b/Sources/InfomaniakLogin/Model/ApiToken.swift
@@ -1,0 +1,84 @@
+/*
+ Copyright 2023 Infomaniak Network SA
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+@objc public class ApiToken: NSObject, Codable {
+    @objc public var accessToken: String
+    @objc public var expiresIn: Int
+    @objc public var refreshToken: String
+    @objc public var scope: String
+    @objc public var tokenType: String
+    @objc public var userId: Int
+    @objc public var expirationDate: Date
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+        case tokenType = "token_type"
+        case userId = "user_id"
+        case scope
+        case expirationDate
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        accessToken = try values.decode(String.self, forKey: .accessToken)
+        expiresIn = try values.decode(Int.self, forKey: .expiresIn)
+        refreshToken = try values.decode(String.self, forKey: .refreshToken)
+        scope = try values.decode(String.self, forKey: .scope)
+        tokenType = try values.decode(String.self, forKey: .tokenType)
+        userId = try values.decode(Int.self, forKey: .userId)
+
+        let newExpirationDate = Date().addingTimeInterval(TimeInterval(Double(expiresIn)))
+        expirationDate = try values.decodeIfPresent(Date.self, forKey: .expirationDate) ?? newExpirationDate
+    }
+
+    public init(
+        accessToken: String,
+        expiresIn: Int,
+        refreshToken: String,
+        scope: String,
+        tokenType: String,
+        userId: Int,
+        expirationDate: Date
+    ) {
+        self.accessToken = accessToken
+        self.expiresIn = expiresIn
+        self.refreshToken = refreshToken
+        self.scope = scope
+        self.tokenType = tokenType
+        self.userId = userId
+        self.expirationDate = expirationDate
+    }
+}
+
+// MARK: - Token Logging
+
+public extension ApiToken {
+    var truncatedAccessToken: String {
+        truncateToken(accessToken)
+    }
+
+    var truncatedRefreshToken: String {
+        truncateToken(refreshToken)
+    }
+
+    internal func truncateToken(_ token: String) -> String {
+        String(token.prefix(4) + "-*****-" + token.suffix(4))
+    }
+}

--- a/Sources/InfomaniakLogin/Model/LoginApiError.swift
+++ b/Sources/InfomaniakLogin/Model/LoginApiError.swift
@@ -1,0 +1,28 @@
+/*
+ Copyright 2023 Infomaniak Network SA
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/// An  api error for `InfomaniakLogin` form
+@objc public class LoginApiError: NSObject, Codable {
+    @objc public let error: String
+    @objc public let errorDescription: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+    }
+}

--- a/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
+++ b/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
@@ -1,0 +1,156 @@
+/*
+ Copyright 2023 Infomaniak Network SA
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/// Something that can keep the network stack authenticated
+public protocol InfomaniakNetworkLoginable {
+    /// Get an api token async (callback on background thread)
+    func getApiTokenUsing(code: String, codeVerifier: String, completion: @escaping (ApiToken?, Error?) -> Void)
+
+    /// Refresh api token async (callback on background thread)
+    func refreshToken(token: ApiToken, completion: @escaping (ApiToken?, Error?) -> Void)
+
+    /// Delete an api token async
+    func deleteApiToken(token: ApiToken, onError: @escaping (Error) -> Void)
+}
+
+public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
+    private let config: InfomaniakLogin.Config
+    private let tokenApiURL: URL
+
+    // MARK: Public
+
+    public init(config: InfomaniakLogin.Config) {
+        self.config = config
+        tokenApiURL = config.loginURL.appendingPathComponent("token")
+    }
+
+    public func getApiTokenUsing(code: String, codeVerifier: String, completion: @escaping (ApiToken?, Error?) -> Void) {
+        var request = URLRequest(url: tokenApiURL)
+
+        let parameterDictionary: [String: Any] = [
+            "grant_type": "authorization_code",
+            "client_id": config.clientId,
+            "code": code,
+            "code_verifier": codeVerifier,
+            "redirect_uri": config.redirectURI
+        ]
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = parameterDictionary.percentEncoded()
+
+        getApiToken(request: request, completion: completion)
+    }
+
+    public func refreshToken(token: ApiToken, completion: @escaping (ApiToken?, Error?) -> Void) {
+        var request = URLRequest(url: tokenApiURL)
+
+        let parameterDictionary: [String: Any] = [
+            "grant_type": "refresh_token",
+            "client_id": config.clientId,
+            "refresh_token": token.refreshToken
+        ]
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = parameterDictionary.percentEncoded()
+
+        getApiToken(request: request, completion: completion)
+    }
+
+    public func deleteApiToken(token: ApiToken, onError: @escaping (Error) -> Void) {
+        var request = URLRequest(url: tokenApiURL)
+        request.addValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
+        request.httpMethod = "DELETE"
+
+        URLSession.shared.dataTask(with: request) { data, response, sessionError in
+            guard let response = response as? HTTPURLResponse, let data else {
+                if let sessionError {
+                    onError(sessionError)
+                }
+                return
+            }
+
+            do {
+                if !response.isSuccessful() {
+                    let apiDeleteToken = try JSONDecoder().decode(ApiDeleteToken.self, from: data)
+                    onError(NSError(
+                        domain: apiDeleteToken.error!,
+                        code: response.statusCode,
+                        userInfo: ["Error": apiDeleteToken.error!]
+                    ))
+                }
+            } catch {
+                onError(error)
+            }
+        }.resume()
+    }
+
+    // MARK: Private
+
+    /// Make the get token network call
+    private func getApiToken(request: URLRequest, completion: @escaping (ApiToken?, Error?) -> Void) {
+        let session = URLSession.shared
+        session.dataTask(with: request) { data, response, sessionError in
+            guard let response = response as? HTTPURLResponse,
+                  let data = data, data.count > 0 else {
+                completion(nil, sessionError)
+                return
+            }
+
+            do {
+                if response.isSuccessful() {
+                    let apiToken = try JSONDecoder().decode(ApiToken.self, from: data)
+                    completion(apiToken, nil)
+                } else {
+                    let apiError = try JSONDecoder().decode(LoginApiError.self, from: data)
+                    completion(nil, NSError(domain: apiError.error, code: response.statusCode, userInfo: ["Error": apiError]))
+                }
+            } catch {
+                completion(nil, error)
+            }
+        }.resume()
+    }
+}
+
+extension HTTPURLResponse {
+    func isSuccessful() -> Bool {
+        return statusCode >= 200 && statusCode <= 299
+    }
+}
+
+extension Dictionary {
+    func percentEncoded() -> Data? {
+        return map { key, value in
+            let escapedKey = "\(key)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+            let escapedValue = "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+            return escapedKey + "=" + escapedValue
+        }
+        .joined(separator: "&")
+        .data(using: .utf8)
+    }
+}
+
+extension CharacterSet {
+    static let urlQueryValueAllowed: CharacterSet = {
+        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+        let subDelimitersToEncode = "!$&'()*+,;="
+
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+        return allowed
+    }()
+}

--- a/login-Example/login-Example/AppDelegate.swift
+++ b/login-Example/login-Example/AppDelegate.swift
@@ -39,24 +39,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func setupDI() {
-        do {
-            /// The `InfomaniakLoginable` interface hides the concrete type `InfomaniakLogin`
-            try SimpleResolver.sharedResolver.store(factory: Factory(type: InfomaniakLoginable.self) { _, _ in
-                let clientId = "9473D73C-C20F-4971-9E10-D957C563FA68"
-                let redirectUri = "com.infomaniak.drive://oauth2redirect"
-                let login = InfomaniakLogin(clientId: clientId, redirectUri: redirectUri)
-                return login
-            })
-            
-            /// Chained resolution, the `InfomaniakTokenable` interface uses the `InfomaniakLogin` object as well
-            try SimpleResolver.sharedResolver.store(factory: Factory(type: InfomaniakTokenable.self) { _, resolver in
-                return try resolver.resolve(type: InfomaniakLoginable.self,
-                                            forCustomTypeIdentifier: nil,
-                                            factoryParameters: nil,
-                                            resolver: resolver)
-            })
-        } catch {
-            fatalError("unexpected \(error)")
-        }
+        /// The `InfomaniakLoginable` interface hides the concrete type `InfomaniakLogin`
+        SimpleResolver.sharedResolver.store(factory: Factory(type: InfomaniakLoginable.self) { _, _ in
+            let clientId = "9473D73C-C20F-4971-9E10-D957C563FA68"
+            let redirectUri = "com.infomaniak.drive://oauth2redirect"
+            let login = InfomaniakLogin(config: .init(clientId: clientId, redirectURI: redirectUri))
+            return login
+        })
+
+        /// Chained resolution, the `InfomaniakTokenable` interface uses the `InfomaniakLogin` object as well
+        SimpleResolver.sharedResolver.store(factory: Factory(type: InfomaniakTokenable.self) { _, resolver in
+            return try resolver.resolve(type: InfomaniakLoginable.self,
+                                        forCustomTypeIdentifier: nil,
+                                        factoryParameters: nil,
+                                        resolver: resolver)
+        })
     }
 }

--- a/login-Example/login-Example/AppDelegate.swift
+++ b/login-Example/login-Example/AppDelegate.swift
@@ -14,7 +14,6 @@
  limitations under the License.
  */
 
-import InfomaniakCore
 import InfomaniakDI
 import InfomaniakLogin
 import UIKit


### PR DESCRIPTION
Some code was brought back from core to prevent interlocking dependencies and responsability spreading.

This is a breaking change, core analog PR is here https://github.com/Infomaniak/ios-core/pull/92 