### PR TITLE
feat: Infinite refresh token

### DIFF
--- a/Sources/InfomaniakLogin/Config.swift
+++ b/Sources/InfomaniakLogin/Config.swift
@@ -31,7 +31,7 @@ public extension InfomaniakLogin {
         let loginURL: URL
         let redirectURI: String
         let responseType: ResponseType
-        let accessType: AccessType
+        let accessType: AccessType?
         let hashMode: String
         let hashModeShort: String
 
@@ -50,7 +50,7 @@ public extension InfomaniakLogin {
             loginURL: URL = URL(string: "https://login.infomaniak.com/")!,
             redirectURI: String = "\(Bundle.main.bundleIdentifier ?? "")://oauth2redirect",
             responseType: ResponseType = .code,
-            accessType: AccessType = .offline,
+            accessType: AccessType? = .offline,
             hashMode: String = "SHA-256",
             hashModeShort: String = "S256"
         ) {

--- a/Sources/InfomaniakLogin/InfomaniakLogin.swift
+++ b/Sources/InfomaniakLogin/InfomaniakLogin.swift
@@ -218,12 +218,15 @@ public class InfomaniakLogin: InfomaniakLoginable, InfomaniakTokenable {
         urlComponents?.path = "/authorize"
         urlComponents?.queryItems = [
             URLQueryItem(name: "response_type", value: config.responseType.rawValue),
-            URLQueryItem(name: "access_type", value: config.accessType.rawValue),
             URLQueryItem(name: "client_id", value: config.clientId),
             URLQueryItem(name: "redirect_uri", value: config.redirectURI),
             URLQueryItem(name: "code_challenge_method", value: codeChallengeMethod),
             URLQueryItem(name: "code_challenge", value: codeChallenge)
         ]
+
+        if let accessType = config.accessType?.rawValue {
+            urlComponents?.queryItems?.append(URLQueryItem(name: "access_type", value: accessType))
+        }
 
         if hideCreateAccountButton {
             urlComponents?.queryItems?.append(URLQueryItem(name: "hide_create_account", value: ""))

--- a/Sources/InfomaniakLogin/InfomaniakLoginError.swift
+++ b/Sources/InfomaniakLogin/InfomaniakLoginError.swift
@@ -25,6 +25,7 @@ public enum InfomaniakLoginError: LocalizedError {
     case navigationCancelled(HTTPStatusCode?, URL?)
     case invalidAccessToken(AccessToken?)
     case invalidUrl
+    case noRefreshToken
 
     public var errorDescription: String? {
         switch self {
@@ -38,6 +39,8 @@ public enum InfomaniakLoginError: LocalizedError {
             return "Invalid access token"
         case .invalidUrl:
             return "Invalid url"
+        case .noRefreshToken:
+            return "No refresh token"
         }
     }
 }

--- a/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
+++ b/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
@@ -57,13 +57,23 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
     }
 
     public func refreshToken(token: ApiToken, completion: @escaping (ApiToken?, Error?) -> Void) {
+        guard let refreshToken = token.refreshToken else {
+            completion(nil, InfomaniakLoginError.noRefreshToken)
+            return
+        }
+
         var request = URLRequest(url: tokenApiURL)
 
-        let parameterDictionary: [String: Any] = [
+        var parameterDictionary: [String: Any] = [
             "grant_type": "refresh_token",
             "client_id": config.clientId,
-            "refresh_token": token.refreshToken
+            "refresh_token": refreshToken
         ]
+
+        if config.accessType == .none {
+            parameterDictionary["duration"] = "infinite"
+        }
+
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = parameterDictionary.percentEncoded()


### PR DESCRIPTION
Login has now an init config object
To get an infinite token pass `none` or `nil` for `accessType` in the config.
If you want to keep old behaviour use `accessType` `offline`

If a token needs to be refreshed and the current config has `accessType` `nil` token will be automatically swapped.

Depends on #10 