### PR TITLE
feat: Use Result API + Add async await

### DIFF
--- a/Sources/InfomaniakLogin/InfomaniakLoginError.swift
+++ b/Sources/InfomaniakLogin/InfomaniakLoginError.swift
@@ -26,6 +26,7 @@ public enum InfomaniakLoginError: LocalizedError {
     case invalidAccessToken(AccessToken?)
     case invalidUrl
     case noRefreshToken
+    case unknownNetworkError
 
     public var errorDescription: String? {
         switch self {
@@ -41,6 +42,8 @@ public enum InfomaniakLoginError: LocalizedError {
             return "Invalid url"
         case .noRefreshToken:
             return "No refresh token"
+        case .unknownNetworkError:
+            return "Unknown network error"
         }
     }
 }

--- a/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
+++ b/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
@@ -19,13 +19,13 @@ import Foundation
 /// Something that can keep the network stack authenticated
 public protocol InfomaniakNetworkLoginable {
     /// Get an api token async (callback on background thread)
-    func getApiTokenUsing(code: String, codeVerifier: String, completion: @Sendable @escaping (ApiToken?, Error?) -> Void)
+    func getApiTokenUsing(code: String, codeVerifier: String, completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void)
 
     /// Refresh api token async (callback on background thread)
-    func refreshToken(token: ApiToken, completion: @Sendable @escaping (ApiToken?, Error?) -> Void)
+    func refreshToken(token: ApiToken, completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void)
 
     /// Delete an api token async
-    func deleteApiToken(token: ApiToken, onError: @Sendable @escaping (Error) -> Void)
+    func deleteApiToken(token: ApiToken, completion: @Sendable @escaping (Result<Void, Error>) -> Void)
 }
 
 public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
@@ -39,7 +39,9 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
         tokenApiURL = config.loginURL.appendingPathComponent("token")
     }
 
-    public func getApiTokenUsing(code: String, codeVerifier: String, completion: @Sendable @escaping (ApiToken?, Error?) -> Void) {
+    public func getApiTokenUsing(code: String,
+                                 codeVerifier: String,
+                                 completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void) {
         var request = URLRequest(url: tokenApiURL)
 
         let parameterDictionary: [String: Any] = [
@@ -56,9 +58,9 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
         getApiToken(request: request, completion: completion)
     }
 
-    public func refreshToken(token: ApiToken, completion: @Sendable @escaping (ApiToken?, Error?) -> Void) {
+    public func refreshToken(token: ApiToken, completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void) {
         guard let refreshToken = token.refreshToken else {
-            completion(nil, InfomaniakLoginError.noRefreshToken)
+            completion(.failure(InfomaniakLoginError.noRefreshToken))
             return
         }
 
@@ -81,30 +83,30 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
         getApiToken(request: request, completion: completion)
     }
 
-    public func deleteApiToken(token: ApiToken, onError: @Sendable @escaping (Error) -> Void) {
+    public func deleteApiToken(token: ApiToken, completion: @Sendable @escaping (Result<Void, Error>) -> Void) {
         var request = URLRequest(url: tokenApiURL)
         request.addValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
         request.httpMethod = "DELETE"
 
         URLSession.shared.dataTask(with: request) { data, response, sessionError in
             guard let response = response as? HTTPURLResponse, let data else {
-                if let sessionError {
-                    onError(sessionError)
-                }
+                completion(.failure(sessionError ?? InfomaniakLoginError.unknownNetworkError))
                 return
             }
 
             do {
                 if !response.isSuccessful() {
                     let apiDeleteToken = try JSONDecoder().decode(ApiDeleteToken.self, from: data)
-                    onError(NSError(
+                    completion(.failure(NSError(
                         domain: apiDeleteToken.error!,
                         code: response.statusCode,
                         userInfo: ["Error": apiDeleteToken.error!]
-                    ))
+                    )))
+                } else {
+                    completion(.success(()))
                 }
             } catch {
-                onError(error)
+                completion(.failure(error))
             }
         }.resume()
     }
@@ -112,25 +114,29 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
     // MARK: Private
 
     /// Make the get token network call
-    private func getApiToken(request: URLRequest, completion: @Sendable @escaping (ApiToken?, Error?) -> Void) {
+    private func getApiToken(request: URLRequest, completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void) {
         let session = URLSession.shared
         session.dataTask(with: request) { data, response, sessionError in
             guard let response = response as? HTTPURLResponse,
                   let data = data, data.count > 0 else {
-                completion(nil, sessionError)
+                completion(.failure(sessionError ?? InfomaniakLoginError.unknownNetworkError))
                 return
             }
 
             do {
                 if response.isSuccessful() {
                     let apiToken = try JSONDecoder().decode(ApiToken.self, from: data)
-                    completion(apiToken, nil)
+                    completion(.success(apiToken))
                 } else {
                     let apiError = try JSONDecoder().decode(LoginApiError.self, from: data)
-                    completion(nil, NSError(domain: apiError.error, code: response.statusCode, userInfo: ["Error": apiError]))
+                    completion(.failure(NSError(
+                        domain: apiError.error,
+                        code: response.statusCode,
+                        userInfo: ["Error": apiError]
+                    )))
                 }
             } catch {
-                completion(nil, error)
+                completion(.failure(error))
             }
         }.resume()
     }

--- a/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
+++ b/Sources/InfomaniakLogin/Networking/InfomaniakNetworkLogin.swift
@@ -21,11 +21,20 @@ public protocol InfomaniakNetworkLoginable {
     /// Get an api token async (callback on background thread)
     func getApiTokenUsing(code: String, codeVerifier: String, completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void)
 
+    /// Get an api token
+    func apiTokenUsing(code: String, codeVerifier: String) async throws -> ApiToken
+
     /// Refresh api token async (callback on background thread)
     func refreshToken(token: ApiToken, completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void)
 
+    /// Refresh api token
+    func refreshToken(token: ApiToken) async throws -> ApiToken
+
     /// Delete an api token async
     func deleteApiToken(token: ApiToken, completion: @Sendable @escaping (Result<Void, Error>) -> Void)
+
+    /// Delete an api token
+    func deleteApiToken(token: ApiToken) async throws
 }
 
 public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
@@ -37,6 +46,14 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
     public init(config: InfomaniakLogin.Config) {
         self.config = config
         tokenApiURL = config.loginURL.appendingPathComponent("token")
+    }
+
+    public func apiTokenUsing(code: String, codeVerifier: String) async throws -> ApiToken {
+        return try await withCheckedThrowingContinuation { continuation in
+            getApiTokenUsing(code: code, codeVerifier: codeVerifier) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 
     public func getApiTokenUsing(code: String,
@@ -56,6 +73,14 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
         request.httpBody = parameterDictionary.percentEncoded()
 
         getApiToken(request: request, completion: completion)
+    }
+
+    public func refreshToken(token: ApiToken) async throws -> ApiToken {
+        return try await withCheckedThrowingContinuation { continuation in
+            refreshToken(token: token) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 
     public func refreshToken(token: ApiToken, completion: @Sendable @escaping (Result<ApiToken, Error>) -> Void) {
@@ -81,6 +106,14 @@ public class InfomaniakNetworkLogin: InfomaniakNetworkLoginable {
         request.httpBody = parameterDictionary.percentEncoded()
 
         getApiToken(request: request, completion: completion)
+    }
+
+    public func deleteApiToken(token: ApiToken) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            deleteApiToken(token: token) { result in
+                continuation.resume(with: result)
+            }
+        }
     }
 
     public func deleteApiToken(token: ApiToken, completion: @Sendable @escaping (Result<Void, Error>) -> Void) {

--- a/login-Example/login-Example/AppDelegate.swift
+++ b/login-Example/login-Example/AppDelegate.swift
@@ -38,20 +38,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func setupDI() {
+        let clientId = "9473D73C-C20F-4971-9E10-D957C563FA68"
+        let redirectUri = "com.infomaniak.drive://oauth2redirect"
+        let config = InfomaniakLogin.Config(clientId: clientId, redirectURI: redirectUri, accessType: .none)
         /// The `InfomaniakLoginable` interface hides the concrete type `InfomaniakLogin`
         SimpleResolver.sharedResolver.store(factory: Factory(type: InfomaniakLoginable.self) { _, _ in
-            let clientId = "9473D73C-C20F-4971-9E10-D957C563FA68"
-            let redirectUri = "com.infomaniak.drive://oauth2redirect"
-            let login = InfomaniakLogin(config: .init(clientId: clientId, redirectURI: redirectUri, accessType: .none))
-            return login
+            return InfomaniakLogin(config: config)
         })
 
-        /// Chained resolution, the `InfomaniakTokenable` interface uses the `InfomaniakLogin` object as well
-        SimpleResolver.sharedResolver.store(factory: Factory(type: InfomaniakTokenable.self) { _, resolver in
-            return try resolver.resolve(type: InfomaniakLoginable.self,
-                                        forCustomTypeIdentifier: nil,
-                                        factoryParameters: nil,
-                                        resolver: resolver)
+        /// The `InfomaniakNetworkLoginable` interface hides the concrete type `InfomaniakNetworkLogin`
+        SimpleResolver.sharedResolver.store(factory: Factory(type: InfomaniakNetworkLoginable.self) { _, resolver in
+            return InfomaniakNetworkLogin(config: config)
         })
     }
 }

--- a/login-Example/login-Example/ViewController.swift
+++ b/login-Example/login-Example/ViewController.swift
@@ -113,7 +113,10 @@ class ViewController: UIViewController, InfomaniakLoginDelegate, DeleteAccountDe
         alertController.addAction(UIAlertAction(title: "OK", style: .default) { _ in
             self.dismiss(animated: true, completion: nil)
         })
-        present(alertController, animated: true, completion: nil)
+        Task {
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+            self.present(alertController, animated: true, completion: nil)
+        }
     }
 
     @IBAction func refreshTokenConvert(_ sender: Any) {


### PR DESCRIPTION
All callbacks now use the Result api and can also easily be used in async context with `try await`
`InfomaniakNetworkLoginable` now exposes in async await:
`apiTokenUsing`
`refreshToken`
`deleteApiToken`

This is a breaking change because of the move to Result api.

InfomaniakTokenable was also removed to make the api simpler to use.

We know only use `InfomaniakLoginable` for the UI part and `InfomaniakNetworkLoginable` for the network calls.
